### PR TITLE
Fix: ApplyInterpolatedFrame: only re-Initialize the PlayerVisuals

### DIFF
--- a/src/Core/ReplayPlayback.cs
+++ b/src/Core/ReplayPlayback.cs
@@ -1196,7 +1196,7 @@ public class ReplayPlayback
                     state.visualData = pb.visualData;
                     
                     playbackPlayer.Controller.assignedPlayer.Data.VisualData = newVisualData;
-                    playbackPlayer.Controller.Initialize(playbackPlayer.Controller.assignedPlayer);
+                    playbackPlayer.Controller.PlayerVisuals.Initialize(playbackPlayer.Controller);
 
                     playbackPlayer.Controller.transform.GetChild(9).gameObject.SetActive(false);
                 }


### PR DESCRIPTION
this fixes an issue where PlayerController.Initialize attempts to access physics children that have been deleted on clones
```
[22:35:05.641] [ERROR] [ReplayMod] Il2CppInterop.Runtime.Il2CppException: System.NullReferenceException: Object reference not set to an instance of an object.
--- BEGIN IL2CPP STACK TRACE ---
System.NullReferenceException: Object reference not set to an instance of an object.
  at RUMBLE.Players.Subsystems.PlayerPhysics.UpdateJointConnection () [0x00000] in <00000000000000000000000000000000>:0 
  at RUMBLE.Players.Subsystems.PlayerPhysics.Initialize (RUMBLE.Players.PlayerController controller) [0x00000] in <00000000000000000000000000000000>:0 
  at RUMBLE.Players.PlayerController.Initialize (RUMBLE.Players.Player player) [0x00000] in <00000000000000000000000000000000>:0 
--- END IL2CPP STACK TRACE ---

   at Il2CppInterop.Runtime.Il2CppException.RaiseExceptionIfNecessary(IntPtr returnedException) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Il2CppException.cs:line 36
   at DMD<Il2CppRUMBLE.Players.PlayerController::Initialize>(PlayerController this, Player player)
   at ReplayMod.Core.ReplayPlayback.ApplyInterpolatedFrame(Int32 frameIndex, Single t) in ReplayMod\src\Core\ReplayPlayback.cs:line 1239
   at ReplayMod.Core.ReplayPlayback.UpdatePlayback(Single time) in ReplayMod\src\Core\ReplayPlayback.cs:line 1658
   at ReplayMod.Core.ReplayPlayback.HandlePlayback() in ReplayMod\src\Core\ReplayPlayback.cs:line 127
   at ReplayMod.Core.Main.OnLateUpdate() in ReplayMod\src\Core\Main.cs:line 2149
   at MelonLoader.MelonEventBase`1.Invoke(Action`1 delegateInvoker) in D:\a\MelonLoader\MelonLoader\MelonLoader\Melons\Events\MelonEvent.cs:line 143
   ```